### PR TITLE
チャンネル名の入力できる長さを50文字から20文字に変更

### DIFF
--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -21,7 +21,7 @@ CREATE TABLE channels (
     id serial PRIMARY KEY,
     users_id BIGINT UNSIGNED NOT NULL,
     FOREIGN KEY (users_id) REFERENCES users(id) ON DELETE CASCADE,
-    name varchar(50) UNIQUE NOT NULL,
+    name varchar(20) UNIQUE NOT NULL,
     description varchar(50) NOT NULL,
     is_owner BOOLEAN NOT NULL,
     created_at timestamp not null default current_timestamp,


### PR DESCRIPTION
init.sqlのチャンネルテーブルで
部屋の名前を50文字→20文字に変更しました
