### PR TITLE
メッセージ画面のHTML・CSS作業がほぼ完了

### DIFF
--- a/ChatApp/model.py
+++ b/ChatApp/model.py
@@ -133,7 +133,7 @@ class PostModel:
         try:
             conn = DB.getConnection()
             cur = conn.cursor()
-            sql = "SELECT me.id AS message_id, us.id AS user_id, us.name AS name, content, me.created_at AS created_at FROM messages AS me INNER JOIN users AS us ON me.user_id = us.id WHERE me.channel_id = %s;"
+            sql = "SELECT me.id AS message_id, us.id AS user_id, us.name AS name, content, me.created_at AS created_at FROM messages AS me INNER JOIN users AS us ON me.user_id = us.id WHERE me.channel_id = %s ORDER BY me.created_at ASC;"
             cur.execute(sql, (channel_id))
             messages = cur.fetchall()
             return messages

--- a/ChatApp/static/css/detail.css
+++ b/ChatApp/static/css/detail.css
@@ -38,6 +38,12 @@
     margin-left: 0.3rem;
 }
 
+.message-elements-wrapper {
+    display: flex;
+    align-items: flex-end;
+    margin-bottom: 0.5rem;
+}
+
 
 .message__content {
     background-color: var(--sky);
@@ -65,6 +71,12 @@
     display: flex;
     justify-content: flex-end;
     align-items: flex-end;
+    margin-bottom: 0.5rem;
+}
+
+.my-message-elements__column {
+    display: flex;
+    flex-direction: column;
 }
 
 .my-message__content {
@@ -72,6 +84,7 @@
     display: inline-block;
     padding: 1rem;
     border-radius: 20px;
+    max-width: 560px;
     /* ここに右尻尾 */
 }
 
@@ -104,17 +117,6 @@
     flex-direction: column;
 }
 
-/* レイアウト */
-
-.layout__flex {
-    display: flex;
-    align-items: flex-end;
-}
-
-.layout__column {
-    display: flex;
-    flex-direction: column;
-}
 
 
 /* ----------- post-area ----------- */
@@ -124,10 +126,9 @@
     width: 70%;
     display: flex;
     justify-content: space-around;
-    align-items:center ;
+    align-items:center;
     gap: 2rem;
     margin: 1rem 0;
-
 }
 
 

--- a/ChatApp/static/css/detail.css
+++ b/ChatApp/static/css/detail.css
@@ -1,7 +1,131 @@
-.message—mine {
-    color: blue;
+/* detail.css */
+
+.detail-main-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    align-items: center;
 }
 
-.message—others {
-    color: red;
+
+.messages-area {
+    background-color: white;
+    border: 1.5px solid black;
+    border-radius: 10px;
+    width: 70%;
+    min-width:  640px;
+    height: 640px;
+    overflow: scroll;
+    display: flex;
+    justify-content: center;
 }
+
+.messages-wrapper {
+    width: 90%;
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+/* ---------- 他者のメッセージ ---------- */
+
+.message__name {
+    font-size: small;
+    margin-left: 0.3rem;
+}
+
+
+.message__content {
+    background-color: var(--sky);
+    display: inline-block;
+    padding: 1rem;
+    border-radius: 20px;
+    /* ここに左尻尾 */
+}
+
+.message__timestamp {
+    font-size: small;
+    margin-left: 0.3rem;
+}
+
+
+/* ----------- 自分のメッセージ --------- */
+
+.my-message__name {
+    font-size: small;
+    margin-left: 0.3rem;
+    text-align: right;
+}
+
+.my-message-elements-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    align-items: flex-end;
+}
+
+.my-message__content {
+    background-color: var(--sky);
+    display: inline-block;
+    padding: 1rem;
+    border-radius: 20px;
+    /* ここに右尻尾 */
+}
+
+.my-message__delete-button {
+    border: none;
+    padding: 0.2rem;
+    font-size: small;
+    margin-right: 0.3rem;
+}
+
+.my-message__delete-button:hover {
+    color: var(--error_red);
+    border-style: solid;
+    border-radius: 5px;
+}
+
+.my-message__delete-button-posi {
+    text-align: right;
+}
+
+
+.my-message__timestamp {
+    font-size: small;
+    margin-right: 0.3rem;
+}
+
+
+.timestamp-delete-column {
+    display: flex;
+    flex-direction: column;
+}
+
+/* レイアウト */
+
+.layout__flex {
+    display: flex;
+    align-items: flex-end;
+}
+
+.layout__column {
+    display: flex;
+    flex-direction: column;
+}
+
+
+/* ----------- post-area ----------- */
+
+/* textareaの初期値リセット・初期設定 */
+textarea {
+    resize: none;   
+}
+
+textarea:focus{
+    border: none;
+    outline-color: #008000;
+    outline-style: solid;
+    outline-width: 2px;
+  }
+

--- a/ChatApp/static/css/detail.css
+++ b/ChatApp/static/css/detail.css
@@ -1,9 +1,7 @@
-.channel-tytle{
-    font-weight: bold;
+.message—mine {
+    color: blue;
 }
-.box-right {
-    color: #2196F3;
-}
-.box-left {
-    color: green;
+
+.message—others {
+    color: red;
 }

--- a/ChatApp/static/css/detail.css
+++ b/ChatApp/static/css/detail.css
@@ -1,13 +1,15 @@
-/* detail.css */
-
 .detail-main-wrapper {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1rem;
     align-items: center;
 }
 
+.channel-description {
+    width: 70%;
+    margin-top: 1rem;
+}
 
 .messages-area {
     background-color: white;
@@ -117,15 +119,47 @@
 
 /* ----------- post-area ----------- */
 
-/* textareaの初期値リセット・初期設定 */
-textarea {
-    resize: none;   
+
+.post-area {
+    width: 70%;
+    display: flex;
+    justify-content: space-around;
+    align-items:center ;
+    gap: 2rem;
+    margin: 1rem 0;
+
 }
 
-textarea:focus{
+
+.post__textarea {
+    resize: none;   
+    width: 80%;
+    min-width: 400px;
+    padding: 1rem;
+    min-height: 100px;
+    border-radius: 5px
+}
+
+.post__textarea:focus{
     border: none;
     outline-color: #008000;
     outline-style: solid;
     outline-width: 2px;
-  }
+}
+
+.post__button {
+    display: inline-block;
+    border: none;
+    font-size: 1.2rem;
+    background-color: var(--azuki);
+    color: var(--sky);
+    padding: .75rem;
+    min-width: 160px;
+    border-radius: 10px;
+}
+
+.post__button:hover {
+    background-color: var(--pale_azuki);
+    transition: .5s;
+}
 

--- a/ChatApp/static/css/styles.css
+++ b/ChatApp/static/css/styles.css
@@ -4,3 +4,4 @@
 @import "color.css";
 @import "header.css";
 @import "edit-channel.css";
+@import "detail.css";

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -8,12 +8,17 @@
     <p>{{ channel.description }}</p>
     <p>{{ channel.id }}</p>
 
-    <!-- メッセージの投稿者による条件分岐テスト -->
+    <!-- メッセージの投稿者による条件分岐・名前と時刻をセットで表示-->
     {% for message in messages %}
         {% if message.user_id == user_id %}
+            <p>{{ message.name }}</p>
             <p class="message—mine">{{ message.content }}</p>
+            <p>{{ message.created_at }}</p>
         {% else %}
-            <p class="message—others">{{ message.content }}</p> {% endif %}
+            <p>{{ message.name }}</p>       
+            <p class="message—others">{{ message.content }}</p> 
+            <p>{{ message.created_at }}</p>
+        {% endif %}
     {% endfor %}
 
     <form action="{{ url_for('messageAdd')}}" method="post">

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -6,14 +6,13 @@
 <main>
     <!-- 変数が表示できるかテスト -->
     <p>{{ channel.description }}</p>
-    <p>{{ channel.id }}</p>
 
     <!-- メッセージの投稿者による条件分岐・名前と時刻をセットで表示-->
     {% for message in messages %}
         {% if message.user_id == user_id %}
             <p>{{ message.name }}</p>
             <p class="message—mine">{{ message.content }}</p>
-            <p>{{ message.created_at }}</p>
+            <form action="/delete_message" method="post"><button class="">削除</button></form> 
             <!-- メッセージ投稿時刻のフォーマット変更 -->
             {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
             <p>{{ timestamp }}</p>
@@ -21,7 +20,6 @@
         {% else %}
             <p>{{ message.name }}</p>       
             <p class="message—others">{{ message.content }}</p> 
-            <p>{{ message.created_at }}</p>
             <!-- メッセージ投稿時刻のフォーマット変更 -->
             {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
             <p>{{ timestamp }}</p>

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -14,10 +14,18 @@
             <p>{{ message.name }}</p>
             <p class="message—mine">{{ message.content }}</p>
             <p>{{ message.created_at }}</p>
+            <!-- メッセージ投稿時刻のフォーマット変更 -->
+            {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
+            <p>{{ timestamp }}</p>
+            {% endwith %}
         {% else %}
             <p>{{ message.name }}</p>       
             <p class="message—others">{{ message.content }}</p> 
             <p>{{ message.created_at }}</p>
+            <!-- メッセージ投稿時刻のフォーマット変更 -->
+            {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
+            <p>{{ timestamp }}</p>
+            {% endwith %}
         {% endif %}
     {% endfor %}
 

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -14,7 +14,7 @@
     {% endfor %}
 
     <form action="{{ url_for('messageAdd')}}" method="post">
-        <input type="hidden" name="channel_id" value="{{l channe.id }}">
+        <input type="hidden" name="channel_id" value="{{ channel.id }}">
         <textarea name="content"></textarea>
         <button>送信</button>
     </form>

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -8,9 +8,12 @@
     <p>{{ channel.description }}</p>
     <p>{{ channel.id }}</p>
 
-    <!-- メッセージフォームが機能するかテスト -->
+    <!-- メッセージの投稿者による条件分岐テスト -->
     {% for message in messages %}
-        <p>{{ message.content }}</p>
+        {% if message.user_id == user_id %}
+            <p class="message—mine">{{ message.content }}</p>
+        {% else %}
+            <p class="message—others">{{ message.content }}</p> {% endif %}
     {% endfor %}
 
     <form action="{{ url_for('messageAdd')}}" method="post">

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %} {% block nav_buttons %}
+    <li class="button__text-center"><a href="{{ url_for('index') }}" class="azuki-button">ホームへ戻る</a></li>
+    <li class="button__text-center"><a href="{{ url_for('channelAddIndex') }}" class="azuki-button">部屋を作る</a></li>
+    <li class="button__text-center"><a href="{{ url_for('signout') }}" class="azuki-button">サインアウト</a></li>
+{% endblock %}{% block body %}
+<main>
+    <!-- 変数が表示できるかテスト -->
+    <p>{{ channel.description }}</p>
+    <p>{{ channel.id }}</p>
+
+    <!-- メッセージフォームが機能するかテスト -->
+    {% for message in messages %}
+        <p>{{ message.content }}</p>
+    {% endfor %}
+
+    <form action="{{ url_for('messageAdd')}}" method="post">
+        <input type="hidden" name="channel_id" value="{{l channe.id }}">
+        <textarea name="content"></textarea>
+        <button>送信</button>
+    </form>
+    
+</main>
+{% endblock body %}

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -13,7 +13,7 @@
                         <div class="my-message">
                             <p class="my-message__name">{{ message.name }}(自分)</p>
                             <div class="my-message-elements-wrapper">
-                                <div class="layout__column">
+                                <div class="my-message-elements__column">
                                     <form action="/delete_message" method="post" class="my-message__delete-button-posi"><button class="my-message__delete-button">削除</button></form>      
                                     <!-- メッセージ投稿時刻のフォーマット変更 -->
                                     {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
@@ -26,7 +26,7 @@
                     {% else %}
                         <div class="message">
                             <p class="message__name">{{ message.name }}</p>       
-                            <div class="layout__flex">
+                            <div class="message-elements-wrapper">
                                 <p class="message__content">{{ message.content }}</p> 
                                 <!-- メッセージ投稿時刻のフォーマット変更 -->
                                 {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -4,34 +4,47 @@
     <li class="button__text-center"><a href="{{ url_for('signout') }}" class="azuki-button">サインアウト</a></li>
 {% endblock %}{% block body %}
 <main>
-    <!-- 変数が表示できるかテスト -->
     <p>{{ channel.description }}</p>
-
-    <!-- メッセージの投稿者による条件分岐・名前と時刻をセットで表示-->
-    {% for message in messages %}
-        {% if message.user_id == user_id %}
-            <p>{{ message.name }}</p>
-            <p class="message—mine">{{ message.content }}</p>
-            <form action="/delete_message" method="post"><button class="">削除</button></form> 
-            <!-- メッセージ投稿時刻のフォーマット変更 -->
-            {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
-            <p>{{ timestamp }}</p>
-            {% endwith %}
-        {% else %}
-            <p>{{ message.name }}</p>       
-            <p class="message—others">{{ message.content }}</p> 
-            <!-- メッセージ投稿時刻のフォーマット変更 -->
-            {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
-            <p>{{ timestamp }}</p>
-            {% endwith %}
-        {% endif %}
-    {% endfor %}
-
-    <form action="{{ url_for('messageAdd')}}" method="post">
-        <input type="hidden" name="channel_id" value="{{ channel.id }}">
-        <textarea name="content"></textarea>
-        <button>送信</button>
-    </form>
-    
+    <div class="detail-main-wrapper">
+        <div class="messages-area">
+            <div class="messages-wrapper">
+                {% for message in messages %}
+                    {% if message.user_id == user_id %}
+                        <div class="my-message">
+                            <p class="my-message__name">{{ message.name }}(自分)</p>
+                            <div class="my-message-elements-wrapper">
+                                <div class="layout__column">
+                                    <form action="/delete_message" method="post" class="my-message__delete-button-posi"><button class="my-message__delete-button">削除</button></form>      
+                                    <!-- メッセージ投稿時刻のフォーマット変更 -->
+                                    {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
+                                    <p class="my-message__timestamp">{{ timestamp }}</p>
+                                    {% endwith %}
+                                </div>
+                                <p class="my-message__content">{{ message.content }}</p> 
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="message">
+                            <p class="message__name">{{ message.name }}</p>       
+                            <div class="layout__flex">
+                                <p class="message__content">{{ message.content }}</p> 
+                                <!-- メッセージ投稿時刻のフォーマット変更 -->
+                                {% with timestamp = message.created_at.strftime('%m月%d日 %H:%M') %}
+                                <p class="message__timestamp">{{ timestamp }}</p>
+                                {% endwith %}
+                            </div>   
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+        <div class="post-area">
+            <form action="{{ url_for('messageAdd')}}" method="post">
+                <input type="hidden" name="channel_id" value="{{ channel.id }}">
+                <textarea name="content" autofocus></textarea>
+                <button>送信</button>
+            </form>    
+        </div>
+    </div>  
 </main>
 {% endblock body %}

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -4,8 +4,8 @@
     <li class="button__text-center"><a href="{{ url_for('signout') }}" class="azuki-button">サインアウト</a></li>
 {% endblock %}{% block body %}
 <main>
-    <p>{{ channel.description }}</p>
     <div class="detail-main-wrapper">
+        <p class="channel-description">{{ channel.description }}</p>
         <div class="messages-area">
             <div class="messages-wrapper">
                 {% for message in messages %}
@@ -38,13 +38,11 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="post-area">
-            <form action="{{ url_for('messageAdd')}}" method="post">
-                <input type="hidden" name="channel_id" value="{{ channel.id }}">
-                <textarea name="content" autofocus></textarea>
-                <button>送信</button>
-            </form>    
-        </div>
+        <form class="post-area" action="{{ url_for('messageAdd')}}" method="post">
+            <input type="hidden" name="channel_id" value="{{ channel.id }}">
+            <textarea class="post__textarea" name="content" autofocus></textarea>
+            <button class="post__button">送 信</button>
+        </form>    
     </div>  
 </main>
-{% endblock body %}
+{% endblock body %}d


### PR DESCRIPTION
# やったこと

- メッセージの投稿者をidによって分岐し、メッセージが左右に表示されるようにしました。
- 投稿者本人のメッセージにのみ削除機能を実装しました。
- メッセージ表示の最大幅を指定し、長文であっても一定の幅になったら折り返すように設定しました。
- 作業の途中でメッセージの投稿順序が正しく表示されないことが分かり、バックエンドに相談しました。sqlでorder byしてもらい解決済です。
- 日時表記はフロント側で表記変換しました。バックエンドに報告し、今回はこの仕様のままでいくことになりました。
- 削除ボタンはホバー時のみ目立つように設定してあります。モバイルやタブレットでは体験が悪い仕様かと思いますが、ひとまずこの状態でプルリクエスト出しました。

# このページの残タスク
- メッセージ削除の関数が出来次第、動作を確認する
- 現状、スペースによる空白のメッセージも表示されてしまうのでHTMLで条件を追加する
- まだ投稿がないページに「まだメッセージがありません」と表示させる