### PR TITLE
[fix] 最大幅の指定が抜けていた箇所を修正

### DIFF
--- a/ChatApp/static/css/detail.css
+++ b/ChatApp/static/css/detail.css
@@ -50,6 +50,7 @@
     display: inline-block;
     padding: 1rem;
     border-radius: 20px;
+    max-width: 560px;
     /* ここに左尻尾 */
 }
 
@@ -63,7 +64,7 @@
 
 .my-message__name {
     font-size: small;
-    margin-left: 0.3rem;
+    margin-right: 0.3rem;
     text-align: right;
 }
 


### PR DESCRIPTION
自分以外の投稿メッセージの最大幅を指定し、長文でも折り返すようにしました