### PR TITLE
「まだメッセージがありません。」と表示するコードの挙動を明確にする書き換えを行った

### DIFF
--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -8,6 +8,9 @@
         <p class="channel-description">{{ channel.description }}</p>
         <div class="messages-area">
             <div class="messages-wrapper">
+                {% if messages == () %}
+                    <p class="messages-wrapper__description">まだメッセージがありません。</p>
+                {% endif %}
                 {% for message in messages %}
                     {% if message.user_id == user_id %}
                         <div class="my-message">
@@ -35,8 +38,6 @@
                             </div>   
                         </div>
                     {% endif %}
-                {% else %}
-                    <p class="messages-wrapper__description">まだメッセージがありません。</p>
                 {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
# やったこと
まだ投稿がないとき、「まだメッセージがありません。」と表示するif文を改善しました。

改良前のコードの見た目はpython特有のfor-else構文に近かったのですが、pythonのfor-else構文であればメッセージがある場合でも最後に「まだメッセージがありません。」と表示されるような書き方になっていました。
「なぜかわからないけどうまくいっている」を避けるため、理解できる書き方に改良しました。